### PR TITLE
ci: add automated stale branch cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,8 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  ci:
+    uses: Jaureguy760/shared-workflows/.github/workflows/ci-python.yml@main
+    with:
+      python-version: '3.11'

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,0 +1,12 @@
+name: Stale Branch Cleanup
+on:
+  schedule:
+    - cron: '0 3 * * 0'  # Weekly on Sunday at 3am UTC
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    uses: Jaureguy760/shared-workflows/.github/workflows/stale-branches.yml@main
+    with:
+      days-stale: 14
+      exclude-branches: 'main,master,dev,develop'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,8 @@
+name: Stale Issues
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 6am UTC
+
+jobs:
+  stale:
+    uses: Jaureguy760/shared-workflows/.github/workflows/stale-issues.yml@main


### PR DESCRIPTION
Adds weekly stale-branches.yml workflow that auto-deletes branches with no commits in 14+ days. Uses Jaureguy760/shared-workflows reusable workflow.